### PR TITLE
Hotfix for relevance model

### DIFF
--- a/neurons/miners/openai/README.md
+++ b/neurons/miners/openai/README.md
@@ -26,6 +26,18 @@ For more configuration options related to the wallet, axon, subtensor, logging, 
 
 To run the OpenAI Bittensor Miner with default settings, use the following command:
 
+```bash
+python3 neurons/miners/openai/miner.py \
+    --wallet.name <<your-wallet-name>> \
+    --wallet.hotkey <<your-hotkey>>     
 ```
-python3 neurons/miners/openai/miner.py
+
+You can easily change some key parameters at the CLI, e.g.:
+```bash
+python3 neurons/miners/openai/miner.py \
+    --wallet.name <<your-wallet-name>> \
+    --wallet.hotkey <<your-hotkey>> 
+    --neuron.model_id gpt-4-1106-preview # default value is gpt3.5 turbo
+    --neuron.max_tokens 1024 # default value is 256    
+    --neuron.temperature 0.9 # default value is 0.7
 ```

--- a/neurons/miners/openai/miner.py
+++ b/neurons/miners/openai/miner.py
@@ -49,10 +49,10 @@ class OpenAIMiner(Miner):
     def __init__(self, config=None):
         super().__init__(config=config)
 
-        bt.logging.info(f"Initializing with model {self.config.neuron.model_name}...")
+        bt.logging.info(f"Initializing with model {self.config.neuron.model_id}...")
 
         if self.config.wandb.on:
-            self.identity_tags =  ("openai_miner", ) + (self.config.neuron.model_name, )
+            self.identity_tags =  ("openai_miner", ) + (self.config.neuron.model_id, )
         
         _ = load_dotenv(find_dotenv()) 
         api_key = os.environ.get("OPENAI_API_KEY")        
@@ -63,8 +63,6 @@ class OpenAIMiner(Miner):
             model_name=self.config.neuron.model_id,
             max_tokens = self.config.neuron.max_tokens,
             temperature = self.config.neuron.temperature,            
-            presence_penalty = self.config.neuron.presence_penalty,
-            frequency_penalty = self.config.neuron.frequency_penalty,
         )
 
         self.system_prompt = "You are a friendly chatbot who always responds concisely and helpfully. You are honest about things you don't know."
@@ -77,7 +75,7 @@ class OpenAIMiner(Miner):
         bt.logging.info(f"Total Tokens: {cb.total_tokens}")
         bt.logging.info(f"Prompt Tokens: {cb.prompt_tokens}")
         bt.logging.info(f"Completion Tokens: {cb.completion_tokens}")
-        bt.logging.info(f"Total Cost (USD): ${cb.total_cost}")
+        bt.logging.info(f"Total Cost (USD): ${round(cb.total_cost,4)}")
 
         self.accumulated_total_tokens += cb.total_tokens
         self.accumulated_prompt_tokens += cb.prompt_tokens

--- a/neurons/miners/openai/miner.py
+++ b/neurons/miners/openai/miner.py
@@ -44,62 +44,27 @@ class OpenAIMiner(Miner):
         Adds OpenAI-specific arguments to the command line parser.
         """
         super().add_args(parser)
-        parser.add_argument(
-            "--openai.model_name",
-            type=str,
-            default="gpt-3.5-turbo-1106",
-            help="OpenAI model to use for completion.",
-        )
-
-        parser.add_argument(
-            "--openai.temperature",
-            type=float,
-            default=0.9,
-            help="Temperature of openai model",
-        )
-
-        parser.add_argument(
-            "--openai.max_tokens",
-            type=int,
-            default=500,
-            help="The maximum number of tokens to generate in the completion.",
-        )
-
-        parser.add_argument(
-            "--openai.presence_penalty",
-            type=float,
-            default=0.1,
-            help="Penalty for tokens based on their presence in the text so far.",
-        )
-        
-        parser.add_argument(
-            "--openai.frequency_penalty",
-            type=float,
-            default=0.1,
-            help="Penalty for tokens based on their frequency in the text so far.",
-        )
-
 
 
     def __init__(self, config=None):
         super().__init__(config=config)
 
-        bt.logging.info(f"Initializing with model {self.config.openai.model_name}...")
+        bt.logging.info(f"Initializing with model {self.config.neuron.model_name}...")
 
         if self.config.wandb.on:
-            self.identity_tags =  ("openai_miner", ) + (self.config.openai.model_name, )
+            self.identity_tags =  ("openai_miner", ) + (self.config.neuron.model_name, )
         
         _ = load_dotenv(find_dotenv()) 
         api_key = os.environ.get("OPENAI_API_KEY")        
 
         # Set openai key and other args
         self.model = ChatOpenAI(
-            model_name=self.config.openai.model_name,
-            api_key=api_key,                        
-            max_tokens = self.config.openai.max_tokens,
-            temperature = self.config.openai.temperature,            
-            presence_penalty = self.config.openai.presence_penalty,
-            frequency_penalty = self.config.openai.frequency_penalty,
+            api_key=api_key,
+            model_name=self.config.neuron.model_id,
+            max_tokens = self.config.neuron.max_tokens,
+            temperature = self.config.neuron.temperature,            
+            presence_penalty = self.config.neuron.presence_penalty,
+            frequency_penalty = self.config.neuron.frequency_penalty,
         )
 
         self.system_prompt = "You are a friendly chatbot who always responds concisely and helpfully. You are honest about things you don't know."

--- a/neurons/miners/openai/requirements.txt
+++ b/neurons/miners/openai/requirements.txt
@@ -1,5 +1,5 @@
 # TODO: Are we expecting that the miners should install the validator dependency first?
 # If so, we need to make it clear on the README. Otherwise, we should have a completely separated requirements for the miner
-openai
+openai==1.9.0
 langchain==0.1.0
 python-dotenv

--- a/neurons/miners/wiki_agent/README.md
+++ b/neurons/miners/wiki_agent/README.md
@@ -1,0 +1,34 @@
+# WikiAgent Bittensor Miner
+This repository contains a Bittensor Miner that uses a simple ReACT langchain agent to retrieve data from OpenAI's model alongside the wikipedia tool. The miner connects to the Bittensor network, registers its wallet, and serves the GPT model to the network.
+
+## Prerequisites
+
+- Python 3.8+
+- OpenAI Python API (https://github.com/openai/openai)
+
+## Installation
+
+1. Clone the repository 
+```bash
+git clone https://github.com/opentensor/prompting.git
+```
+
+2. Install the required packages for the [repository requirements](../../../requirements.txt) with `pip install -r requirements.txt`
+3. Install the required packages for the [wikipedia agent miner](requirements.txt) with `pip install -r requirements.txt`
+3. Ensure that you have a `.env` file with your `OPENAI_API` key
+```.env
+echo OPENAI_API_KEY=YOUR-KEY > .env
+```
+
+For more configuration options related to the wallet, axon, subtensor, logging, and metagraph, please refer to the Bittensor documentation.
+
+## Example Usage
+
+To run the WikiAgent Bittensor Miner with default settings, we recommend using the model `gpt-3.5-turbo-16k` or any model with a big context window. You can run the miner using the following command:
+
+```bash
+python3 neurons/miners/wiki_agent/miner.py \
+    --wallet.name <<your-wallet-name>> \
+    --wallet.hotkey <<your-hotkey>>
+    --neuron.model_id gpt-3.5-turbo-16k
+```

--- a/neurons/miners/wiki_agent/agent.py
+++ b/neurons/miners/wiki_agent/agent.py
@@ -3,7 +3,7 @@ from langchain.agents import Tool
 from langchain.agents import Tool, AgentExecutor, LLMSingleActionAgent, AgentOutputParser
 from langchain.schema import AgentAction, AgentFinish, OutputParserException
 import re
-import wikipedia
+import bittensor as bt
 from typing import Union
 from typing import List
 from langchain.prompts import StringPromptTemplate
@@ -84,7 +84,7 @@ class CustomOutputParser(AgentOutputParser):
 
 
 class WikiAgent:
-    def __init__(self):
+    def __init__(self, model_id: str, model_temperature: float):
         self.wikipedia = WikipediaAPIWrapper()
         tools = [    
             Tool(
@@ -102,7 +102,8 @@ class WikiAgent:
             input_variables=["input", "intermediate_steps"]
         )
 
-        llm = OpenAI(temperature=0)
+        bt.logging.info(f"Initializing agent with model_id: {model_id} and model_temperature: {model_temperature}")
+        llm = OpenAI(model_name=model_id, temperature=model_temperature)
 
 
         llm_chain = LLMChain(llm=llm, prompt=prompt)
@@ -112,10 +113,10 @@ class WikiAgent:
             llm_chain=llm_chain,
             output_parser=output_parser,
             stop=["\nObservation:"],
-            allowed_tools=tools
+            allowed_tools=tools,            
         )
 
-        self.agent_executor = AgentExecutor.from_agent_and_tools(agent=agent, tools=tools, verbose=True)
+        self.agent_executor = AgentExecutor.from_agent_and_tools(agent=agent, tools=tools, verbose=True, handle_parsing_errors=True)
         
 
     def run(self, input: str) -> str:

--- a/neurons/miners/wiki_agent/miner.py
+++ b/neurons/miners/wiki_agent/miner.py
@@ -15,23 +15,14 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import os
 import time
 import bittensor as bt
 import argparse
 # Bittensor Miner Template:
-import prompting
 from prompting.protocol import PromptingSynapse
 # import base miner class which takes care of most of the boilerplate
 from neurons.miner import Miner
-
-from langchain.prompts import ChatPromptTemplate
-from langchain_core.output_parsers import StrOutputParser
-from langchain.chat_models import ChatOpenAI
-from langchain.utilities import WikipediaAPIWrapper
 from dotenv import load_dotenv, find_dotenv
-from langchain import OpenAI
-from langchain.agents import Tool, initialize_agent
 from agent import WikiAgent
 from langchain.callbacks import get_openai_callback
 
@@ -47,20 +38,14 @@ class WikipediaAgentMiner(Miner):
         Adds OpenAI-specific arguments to the command line parser.
         """
         super().add_args(parser)
-        parser.add_argument(
-            "--openai.model_name",
-            type=str,
-            default="gpt-3.5-turbo-16k",
-            help="OpenAI model to use for completion.",
-        )    
 
     def __init__(self, config=None):
         super().__init__(config=config)
         
-        bt.logging.info(f"🤖📖 Initializing wikipedia agent with model {self.config.openai.model_name}...")
+        bt.logging.info(f"🤖📖 Initializing wikipedia agent with model {self.config.neuron.model_id}...")
 
         if self.config.wandb.on:
-            self.identity_tags = ("wikipedia_agent_miner", ) + (self.config.openai.model_name, )
+            self.identity_tags = ("wikipedia_agent_miner", ) + (self.config.neuron.model_id, )
         
         _ = load_dotenv(find_dotenv()) 
                 

--- a/neurons/miners/wiki_agent/miner.py
+++ b/neurons/miners/wiki_agent/miner.py
@@ -49,7 +49,7 @@ class WikipediaAgentMiner(Miner):
         
         _ = load_dotenv(find_dotenv()) 
                 
-        self.agent = WikiAgent()
+        self.agent = WikiAgent(self.config.neuron.model_id, self.config.neuron.temperature)
         self.accumulated_total_tokens = 0
         self.accumulated_prompt_tokens = 0
         self.accumulated_completion_tokens = 0

--- a/neurons/miners/wiki_agent/requirements.txt
+++ b/neurons/miners/wiki_agent/requirements.txt
@@ -1,5 +1,5 @@
 # If so, we need to make it clear on the README. Otherwise, we should have a completely separated requirements for the miner
-openai
-langchain
+openai==0.28
+langchain==0.1.0
 python-dotenv
 wikipedia

--- a/neurons/miners/zephyr/README.md
+++ b/neurons/miners/zephyr/README.md
@@ -1,0 +1,39 @@
+# Zephyr Bittensor Miner
+This repository contains a Bittensor Miner that uses [HuggingFaceH4/zephyr-7b-beta](https://huggingface.co/HuggingFaceH4/zephyr-7b-beta). The miner connects to the Bittensor network, registers its wallet, and serves the zephyr model to the network.
+
+## Prerequisites
+
+- Python 3.8+
+- OpenAI Python API (https://github.com/openai/openai)
+
+## Installation
+1. Clone the repository 
+```bash
+git clone https://github.com/opentensor/prompting.git
+```
+2. Install the required packages for the [repository requirements](../../../requirements.txt) with `pip install -r requirements.txt`
+3. Install the required packages for the [wikipedia agent miner](requirements.txt) with `pip install -r requirements.txt`
+```
+
+For more configuration options related to the wallet, axon, subtensor, logging, and metagraph, please refer to the Bittensor documentation.
+
+## Example Usage
+
+To run the Zephyr Bittensor Miner with default settings, use the following command:
+```bash
+python3 neurons/miners/zephyr/miner.py \
+    --wallet.name <<your-wallet-name>> \
+    --wallet.hotkey <<your-hotkey>>
+    --neuron.model_id HuggingFaceH4/zephyr-7b-beta
+```
+
+You will need 18GB of GPU to run this miner in comfortable settings.
+
+You can also run the quantized version of this model that takes ~10GB of GPU RAM by adding the flag `--neuron.load_quantized`:
+```bash
+python3 neurons/miners/zephyr/miner.py \
+    --wallet.name <<your-wallet-name>> \
+    --wallet.hotkey <<your-hotkey>>
+    --neuron.model_id HuggingFaceH4/zephyr-7b-beta
+    --neuron.load_quantized True
+```

--- a/neurons/miners/zephyr/miner.py
+++ b/neurons/miners/zephyr/miner.py
@@ -17,7 +17,6 @@
 
 import time
 import torch
-import typing
 import argparse
 import bittensor as bt
 
@@ -39,24 +38,12 @@ class ZephyrMiner(Miner):
 
     python neurons/miners/zephyr/miner.py --wallet.name <wallet_name> --wallet.hotkey <wallet_hotkey> --subtensor.network <network> --netuid <netuid> --axon.port <port> --axon.external_port <port> --logging.debug True --neuron.model_id HuggingFaceH4/zephyr-7b-beta --neuron.system_prompt "Hello, I am a chatbot. I am here to help you with your questions." --neuron.max_tokens 64 --neuron.do_sample True --neuron.temperature 0.9 --neuron.top_k 50 --neuron.top_p 0.95 --wandb.on True --wandb.entity sn1 --wandb.project_name miners_experiments
     """
-
     @classmethod
     def add_args(cls, parser: argparse.ArgumentParser):
         """
         Adds arguments to the command line parser.
         """
         super().add_args(parser)
-        parser.add_argument(
-            "--neuron.model_id",
-            type=str,
-            default="HuggingFaceH4/zephyr-7b-beta",
-        )
-
-        parser.add_argument(
-            "--neuron.load_quantized",
-            type=str,
-            default=False,
-        )
 
     def __init__(self, config=None):
         super().__init__(config=config)
@@ -81,8 +68,7 @@ class ZephyrMiner(Miner):
             device=self.device,
             mock=self.config.mock,
             model_kwargs=model_kwargs,
-        )
-        
+        )        
 
         self.system_prompt = "You are a friendly chatbot who always responds concisely and helpfully. You are honest about things you don't know."
 

--- a/prompting/rewards/relevance.py
+++ b/prompting/rewards/relevance.py
@@ -20,7 +20,12 @@ class RelevanceRewardModel(BaseRewardModel):
         self.threshold = threshold
         self.model = AnglE.from_pretrained(
             "WhereIsAI/UAE-Large-V1", pooling_strategy=pooling_strategy, device=device
-        )
+        )        
+        if device.startswith("cuda"):
+            # This line is necessary to pass the model to the device defined at its initialization
+            self.model = self.model.cuda()
+
+
 
     def reward(self, reference: str, completions: List[str]) -> BatchRewardOutput:
         """Calculates the cosine similarity between sentence embeddings of the reference and completions.

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -143,6 +143,20 @@ def add_miner_args(cls, parser):
     )
 
     parser.add_argument(
+        "--neuron.model_id",
+        type=str,
+        help="The model to use for the validator.",
+        default="gpt-3.5-turbo-1106",
+    )
+
+    parser.add_argument(
+        "--neuron.load_quantized",
+        type=str,
+        default=False,
+        help="Load quantized model.",
+    )
+
+    parser.add_argument(
         "--blacklist.force_validator_permit",
         action="store_true",
         help="If set, we will force incoming requests to have a permit.",
@@ -189,6 +203,20 @@ def add_miner_args(cls, parser):
         type=float,
         default=0.95,
         help="Nucleus sampling parameter, top_p probability mass.",
+    )
+
+    parser.add_argument(
+        "--neuron.presence_penalty",
+        type=float,
+        default=0.1,
+        help="Penalty for tokens based on their presence in the text so far.",
+    )
+    
+    parser.add_argument(
+        "--neuron.frequency_penalty",
+        type=float,
+        default=0.1,
+        help="Penalty for tokens based on their frequency in the text so far.",
     )
 
     parser.add_argument(

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -206,20 +206,6 @@ def add_miner_args(cls, parser):
     )
 
     parser.add_argument(
-        "--neuron.presence_penalty",
-        type=float,
-        default=0.1,
-        help="Penalty for tokens based on their presence in the text so far.",
-    )
-    
-    parser.add_argument(
-        "--neuron.frequency_penalty",
-        type=float,
-        default=0.1,
-        help="Penalty for tokens based on their frequency in the text so far.",
-    )
-
-    parser.add_argument(
         "--neuron.stop_on_forward_exception",
         type=bool,
         default=False,


### PR DESCRIPTION
It seems that we need `self.model.cuda()` to bring the model into memory.  This function brings the model to the device specified on the model initialization, and it's defined in the angle lib as:
```python
    def cuda(self):
        if self.load_kbit is None:
            self.backbone = self.backbone.to(torch.device(self.device))
        return self
```
Without `model.cuda()`, the test validator was throwing the classic exception _tensors are not in the same device (gpu and cpu)_ on encoding

Other changes included in the PR:
- normalizes configs for miners
- adds README for wiki agent and zephyr miner
- overall adjustments on dependencies and wiki agent