### PR TITLE
Features/decay scores

### DIFF
--- a/prompting/base/validator.py
+++ b/prompting/base/validator.py
@@ -323,6 +323,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # shape: [ metagraph.n ]
         alpha = self.config.neuron.moving_average_alpha
         self.scores = alpha * step_rewards + (1 - alpha) * self.scores
+        self.scores = (self.scores - self.config.decay_alpha).clamp(min=0)
         bt.logging.debug(f"Updated moving avg scores: {self.scores}")
 
     def save_state(self):

--- a/prompting/base/validator.py
+++ b/prompting/base/validator.py
@@ -323,7 +323,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # shape: [ metagraph.n ]
         alpha = self.config.neuron.moving_average_alpha
         self.scores = alpha * step_rewards + (1 - alpha) * self.scores
-        self.scores = (self.scores - self.config.decay_alpha).clamp(min=0)
+        self.scores = (self.scores - self.config.neuron.decay_alpha).clamp(min=0)
         bt.logging.debug(f"Updated moving avg scores: {self.scores}")
 
     def save_state(self):

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -305,7 +305,14 @@ def add_validator_args(cls, parser):
         "--neuron.moving_average_alpha",
         type=float,
         help="Moving average alpha parameter, how much to add of the new observation.",
-        default=0.05,
+        default=0.1,
+    )
+
+    parser.add_argument(
+        "--neuron.decay_alpha",
+        type=float,
+        help="Constant decay rate for the moving average score.",
+        default=0.001,
     )
 
     parser.add_argument(
@@ -324,7 +331,7 @@ def add_validator_args(cls, parser):
         help="The maximum number of TAO allowed to query a validator with a vpermit.",
             default=4096,
         )
-    
+
     parser.add_argument(
         "--wandb.project_name",
         type=str,


### PR DESCRIPTION
Introduces a decay alpha which decreases ALL scores by a small amount of every step. This is effectively a ping for the miners so that those which are not alive pay a cost for not participating.

An initial value of `decay_alpha=0.001` is set which would reduce all scores by 0.001 on every `run_step`. Given that currently `step_size=50`, the expected number of steps before a given UID is queried is around 1000/50 = 20. 

This means that a UIDs score will tend to decrease by **0.02** between subsequent queries due to score decay, which is negligible compared to the ~0.3 that is typically scored. The net effect for active UIDs is a uniform drop in all scores by 0.02. 

However, for UIDs that are **not active** this will compound so that their scores drop by 0.02 each time a query is missed - so after 10 missed queries (or 200 steps) their scores will drop by 0.2. In other words, miners that are not consistently alive will be at risk of deregistration.

- EMA alpha is increased from 0.05 -> 0.1.

TODO: unit tests for alpha decay