### PR TITLE
Features/limit repeated queries

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -24,7 +24,6 @@ from prompting.forward import forward
 from prompting.llm import load_pipeline
 from prompting.base.validator import BaseValidatorNeuron
 from prompting.rewards import RewardPipeline
-from prompting.utils.uids import check_uid_availability
 
 class Validator(BaseValidatorNeuron):
     """
@@ -58,8 +57,6 @@ class Validator(BaseValidatorNeuron):
         # Load the reward pipeline
         self.reward_pipeline = RewardPipeline(selected_tasks=self.active_tasks, device=self.device)
 
-        for i, axon in enumerate(self.metagraph.axons):
-            check_uid_availability(self.metagraph, i, self.config.neuron.vpermit_tao_limit)
 
     async def forward(self):
         """

--- a/prompting/base/validator.py
+++ b/prompting/base/validator.py
@@ -323,7 +323,7 @@ class BaseValidatorNeuron(BaseNeuron):
         # shape: [ metagraph.n ]
         alpha = self.config.neuron.moving_average_alpha
         self.scores = alpha * step_rewards + (1 - alpha) * self.scores
-        self.scores = (self.scores - self.config.decay_alpha).clamp(min=0)
+        self.scores = (self.scores - self.config.neuron.decay_alpha).clamp(min=0)
         bt.logging.debug(f"Updated moving avg scores: {self.scores}")
 
     def save_state(self):

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -92,6 +92,7 @@ async def run_step(
         **agent.__state_dict__(full=self.config.neuron.log_full),
         **reward_result.__state_dict__(full=self.config.neuron.log_full),
         **response_event.__state_dict__(),
+        'scores': self.scores.tolist(),
     }
 
     log_event(self, event)

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -92,7 +92,6 @@ async def run_step(
         **agent.__state_dict__(full=self.config.neuron.log_full),
         **reward_result.__state_dict__(full=self.config.neuron.log_full),
         **response_event.__state_dict__(),
-        'scores': self.scores.tolist(),
     }
 
     log_event(self, event)

--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -53,7 +53,7 @@ async def run_step(
     # Record event start time.
     start_time = time.time()
     # Get the list of uids to query for this step.
-    uids = get_random_uids(self, k=k, exclude=exclude or []).to(self.device)
+    uids = get_random_uids(self, exclude=exclude or []).to(self.device)
 
     axons = [self.metagraph.axons[uid] for uid in uids]
     # Make calls to the network with the prompt.

--- a/prompting/utils/config.py
+++ b/prompting/utils/config.py
@@ -348,17 +348,17 @@ def add_validator_args(cls, parser):
 
 
     parser.add_argument(
-        "--neuron.query_unique_coldkeys",
-        action="store_true",
-        help="Only query a single hotkey per coldkey.",
-        default=False,
+        "--neuron.unique_coldkey_prob",
+        type=float,
+        help="Probability of querying a given coldkey only once per step.",
+        default=0.9,
         )
 
     parser.add_argument(
-        "--neuron.query_unique_ips",
-        action="store_true",
-        help="Only query a single hotkey per ip.",
-        default=False,
+        "--neuron.unique_ip_prob",
+        type=float,
+        help="Probability of querying a given ip only once per step.",
+        default=0.9,
         )
 
 def config(cls):

--- a/prompting/utils/uids.py
+++ b/prompting/utils/uids.py
@@ -25,7 +25,7 @@ def get_random_uids(
     all_ips = [axon.ip for axon in self.metagraph.axons]
     for uid in all_uids:
 
-        if exclude is not None and uid in exclude:
+        if uid == self.uid or (exclude is not None and uid in exclude):
             continue
 
         # Filter non serving axons.

--- a/prompting/utils/uids.py
+++ b/prompting/utils/uids.py
@@ -62,7 +62,7 @@ def get_random_uids(
         ips[ip] = ips.get(ip, 0 ) + 1
 
         uids.append(uid)
-        if len(uids) == self.step_size:
+        if len(uids) == self.config.neuron.sample_size:
             break
 
     self._selected_coldkeys = coldkeys

--- a/prompting/utils/uids.py
+++ b/prompting/utils/uids.py
@@ -1,5 +1,5 @@
 import torch
-import random
+import numpy as np
 import bittensor as bt
 from typing import List
 
@@ -21,7 +21,7 @@ def get_random_uids(
     coldkeys = {}
     ips = {}
     # shuffled list of all UIDs
-    all_uids = random.choices(self.metagraph.uids.tolist(), k=self.metagraph.n.item())
+    all_uids = np.random.choice(range(self.metagraph.n.item()), size=self.metagraph.n.item(), replace=False)
     all_coldkeys = self.metagraph.coldkeys
     all_ips = [axon.ip for axon in self.metagraph.axons]
     for uid in all_uids:
@@ -55,7 +55,7 @@ def get_random_uids(
             ip_threshold = (1-self.config.neuron.unique_ip_prob) ** ip_counts
 
             # Take the product of the two probabilities as the likelihood of querying the same coldkey and ip again
-            if random.random() > ck_threshold * ip_threshold:
+            if np.random.random() > ck_threshold * ip_threshold:
                 continue
 
         coldkeys[coldkey] = coldkeys.get(coldkey, 0 ) + 1

--- a/prompting/utils/uids.py
+++ b/prompting/utils/uids.py
@@ -4,39 +4,6 @@ import bittensor as bt
 from typing import List
 
 
-def check_uid_availability(
-    metagraph: "bt.metagraph.Metagraph", uid: int, vpermit_tao_limit: int, coldkeys: set = None, ips: set = None,
-) -> bool:
-    """Check if uid is available. The UID should be available if it is serving and has less than vpermit_tao_limit stake
-    Args:
-        metagraph (:obj: bt.metagraph.Metagraph): Metagraph object
-        uid (int): uid to be checked
-        vpermit_tao_limit (int): Validator permit tao limit
-        coldkeys (set): Set of coldkeys to exclude
-        ips (set): Set of ips to exclude
-    Returns:
-        bool: True if uid is available, False otherwise
-    """
-    # Filter non serving axons.
-    if not metagraph.axons[uid].is_serving:
-        bt.logging.debug(f"uid: {uid} is not serving")
-        return False
-      
-    # Filter validator permit > 1024 stake.
-    if metagraph.validator_permit[uid] and metagraph.S[uid] > vpermit_tao_limit:
-        bt.logging.debug(f"uid: {uid} has vpermit and stake ({metagraph.S[uid]}) > {vpermit_tao_limit}")
-        return False
-
-    if coldkeys and metagraph.axons[uid].coldkey in coldkeys:
-        return False
-
-    if ips and metagraph.axons[uid].ip in ips:
-        return False
-
-    # Available otherwise.
-    return True
-
-
 def get_random_uids(
     self, k: int, exclude: List[int] = None
 ) -> torch.LongTensor:
@@ -49,36 +16,57 @@ def get_random_uids(
     Notes:
         If `k` is larger than the number of available `uids`, set `k` to the number of available `uids`.
     """
-    candidate_uids = []
-    avail_uids = []
-    coldkeys = set()
-    ips = set()
-    for uid in range(self.metagraph.n.item()):
-        if uid == self.uid:
+
+    uids = []
+    coldkeys = {}
+    ips = {}
+    # shuffled list of all UIDs
+    all_uids = random.choices(self.metagraph.uids.tolist(), k=self.metagraph.n.item())
+    all_coldkeys = self.metagraph.coldkeys
+    all_ips = [axon.ip for axon in self.metagraph.axons]
+    for uid in all_uids:
+
+        if exclude is not None and uid in exclude:
             continue
 
-        uid_is_available = check_uid_availability(
-            self.metagraph, uid, self.config.neuron.vpermit_tao_limit, coldkeys, ips,
-        )
-        if not uid_is_available:
+        # Filter non serving axons.
+        if not self.metagraph.axons[uid].is_serving:
+            bt.logging.debug(f"uid: {uid} is not serving")
             continue
 
-        if self.config.neuron.query_unique_coldkeys:
-            coldkeys.add(self.metagraph.axons[uid].coldkey)
+        # Filter validator permit > 1024 stake.
+        if self.metagraph.validator_permit[uid] and self.metagraph.S[uid] > self.config.neuron.vpermit_tao_limit:
+            bt.logging.debug(f"uid: {uid} has vpermit and stake ({self.metagraph.S[uid]}) > {self.config.neuron.vpermit_tao_limit}")
+            continue
 
-        if self.config.neuron.query_unique_ips:
-            ips.add(self.metagraph.axons[uid].ip)
+        # get the coldkey for the uid
+        coldkey = all_coldkeys[uid]
+        ip = all_ips[uid]
+        # get the number of times the coldkey has been queried in the current step
+        ck_counts = coldkeys.get(coldkey,0)
+        # get the number of times the ip has been queried in the current step
+        ip_counts = ips.get(ip,0)
+        # if it's already been queried query again with some smaller probability
+        if ck_counts > 0 or ip_counts > 0:
 
-        avail_uids.append(uid)
-        if exclude is None or uid not in exclude:
-            candidate_uids.append(uid)
+            # here we use the probability of not querying the same coldkey
+            # for example if unique_coldkey_prob = 0.9 and the coldkey has already been queried 2 times in this forward pass, then the probability of querying the same coldkey again is (1-0.9)^2=0.01
+            ck_threshold = (1-self.config.neuron.unique_coldkey_prob) ** ck_counts
+            ip_threshold = (1-self.config.neuron.unique_ip_prob) ** ip_counts
 
-    # Check if candidate_uids contain enough for querying, if not grab all avaliable uids
-    available_uids = candidate_uids
-    if len(candidate_uids) < k:
-        available_uids += random.sample(
-            [uid for uid in avail_uids if uid not in candidate_uids],
-            k - len(candidate_uids),
-        )
-    uids = torch.tensor(random.sample(available_uids, k))
-    return uids
+            # Take the product of the two probabilities as the likelihood of querying the same coldkey and ip again
+            if random.random() > ck_threshold * ip_threshold:
+                continue
+
+        coldkeys[coldkey] = coldkeys.get(coldkey, 0 ) + 1
+        ips[ip] = ips.get(ip, 0 ) + 1
+
+        uids.append(uid)
+        if len(uids) == self.step_size:
+            break
+
+    self._selected_coldkeys = coldkeys
+    self._selected_ips = ips
+    if len(uids) < k:
+        bt.logging.warning(f"Only {len(uids)} uids available for querying, requested {k}.")
+    return torch.tensor(uids)

--- a/prompting/utils/uids.py
+++ b/prompting/utils/uids.py
@@ -5,16 +5,15 @@ from typing import List
 
 
 def get_random_uids(
-    self, k: int, exclude: List[int] = None
+    self, exclude: List[int] = None
 ) -> torch.LongTensor:
     """Returns k available random uids from the metagraph.
     Args:
-        k (int): Number of uids to return.
         exclude (List[int]): List of uids to exclude from the random sampling.
     Returns:
         uids (torch.LongTensor): Randomly sampled available uids.
     Notes:
-        If `k` is larger than the number of available `uids`, set `k` to the number of available `uids`.
+        If self.config.neuron.sample_size is larger than the number of available `uids`, the function will return all available `uids`.
     """
 
     uids = []
@@ -67,6 +66,6 @@ def get_random_uids(
 
     self._selected_coldkeys = coldkeys
     self._selected_ips = ips
-    if len(uids) < k:
+    if len(uids) < self.config.neuron.sample_size:
         bt.logging.warning(f"Only {len(uids)} uids available for querying, requested {k}.")
     return torch.tensor(uids)

--- a/prompting/utils/uids.py
+++ b/prompting/utils/uids.py
@@ -67,5 +67,5 @@ def get_random_uids(
     self._selected_coldkeys = coldkeys
     self._selected_ips = ips
     if len(uids) < self.config.neuron.sample_size:
-        bt.logging.warning(f"Only {len(uids)} uids available for querying, requested {k}.")
+        bt.logging.warning(f"Only {len(uids)} uids available for querying, requested {self.config.neuron.sample_size}.")
     return torch.tensor(uids)

--- a/tests/test_uids.py
+++ b/tests/test_uids.py
@@ -3,6 +3,7 @@ import torch
 import random
 import pytest
 from types import SimpleNamespace
+from typing import List
 from prompting.utils.uids import get_random_uids
 
 def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=False, vpermit_tao_limit=1000):

--- a/tests/test_uids.py
+++ b/tests/test_uids.py
@@ -37,7 +37,7 @@ def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=Fals
     )
 
 @pytest.mark.parametrize(
-    "unique_coldkeys, unique_ips, k, expected_result", [
+    "unique_coldkeys, unique_ips, sample_size, expected_result", [
         (False, False, 4, [0, 1, 2, 3]),
         (True, False, 2, [0, 2]),
         (False, True, 2, [0, 1]),

--- a/tests/test_uids.py
+++ b/tests/test_uids.py
@@ -43,7 +43,7 @@ def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=Fals
         (False, True, 2, [0, 1]),
         (True, True, 2, [0, 3])
         ])
-def test_get_random_uids(unique_coldkeys, unique_ips, sample_size, expected_result):
+def test_get_random_uids(unique_coldkeys: bool, unique_ips: bool, sample_size: int, expected_result: List[int]):
 
     mock_neuron = make_mock_neuron(sample_size, unique_coldkeys, unique_ips)
 

--- a/tests/test_uids.py
+++ b/tests/test_uids.py
@@ -42,7 +42,7 @@ def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=Fals
         (False, True, 2, [0, 1]),
         (True, True, 2, [0, 3])
         ])
-def test_get_random_uids(unique_coldkeys, unique_ips, k, expected_result):
+def test_get_random_uids(unique_coldkeys, unique_ips, sample_size, expected_result):
 
     mock_neuron = make_mock_neuron(k, unique_coldkeys, unique_ips)
 

--- a/tests/test_uids.py
+++ b/tests/test_uids.py
@@ -3,18 +3,26 @@ import torch
 import random
 import pytest
 from types import SimpleNamespace
-from typing import List
+from typing import List, Set
 from prompting.utils.uids import get_random_uids
 
-def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=False, vpermit_tao_limit=1000):
+def make_mock_neuron(sample_size, unique_coldkey_prob=0, unique_ip_prob=0, add_validator=False, add_inactive=False, add_validator_above_limit=False):
 
     axons = [
         SimpleNamespace(coldkey="a", ip="0.0.0.1", is_serving=True),
-        SimpleNamespace(coldkey="a", ip="0.0.0.0", is_serving=True),
+        SimpleNamespace(coldkey="a", ip="0.0.0.2", is_serving=True),
         SimpleNamespace(coldkey="b", ip="0.0.0.1", is_serving=True),
-        SimpleNamespace(coldkey="b", ip="0.0.0.0", is_serving=True),
-        SimpleNamespace(coldkey="c", ip="0.0.0.2", is_serving=True), # validator
+        SimpleNamespace(coldkey="b", ip="0.0.0.2", is_serving=True),
+        SimpleNamespace(coldkey="c", ip="1.0.0.0", is_serving=True),
+        SimpleNamespace(coldkey="d", ip="0.1.0.0", is_serving=True),
     ]
+    if add_validator:
+        axons.append(SimpleNamespace(coldkey="e", ip="0.0.1.0", is_serving=True))
+    if add_inactive:
+        axons.append(SimpleNamespace(coldkey="f", ip="0.0.0.1", is_serving=False))
+    if add_validator_above_limit:
+        axons.append(SimpleNamespace(coldkey="g", ip="1.1.1.1", is_serving=True))
+
     metagraph = SimpleNamespace(
         axons = axons,
         coldkeys = [axon.coldkey for axon in axons],
@@ -22,13 +30,16 @@ def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=Fals
         S = torch.zeros(len(axons)),
         n = torch.tensor(len(axons))
     )
+    
+    if add_validator_above_limit:
+        metagraph.S[-1] = 2000
 
     return SimpleNamespace(
-        uid = 4,
+        uid = 6,
         config = SimpleNamespace(
             neuron = SimpleNamespace(
                 sample_size = sample_size,
-                vpermit_tao_limit = vpermit_tao_limit,
+                vpermit_tao_limit = 1000,
                 unique_coldkey_prob = unique_coldkey_prob,
                 unique_ip_prob = unique_ip_prob,
             )
@@ -36,16 +47,29 @@ def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=Fals
         metagraph = metagraph
     )
 
+ALL_IPS = {'0.0.0.1', '0.0.0.2', '1.0.0.0', '0.1.0.0'}
+ALL_COLDKEYS = {'a', 'b', 'c', 'd'}
+
 @pytest.mark.parametrize(
-    "unique_coldkeys, unique_ips, sample_size, expected_result", [
-        (False, False, 4, [0, 1, 2, 3]),
-        (True, False, 2, [0, 2]),
-        (False, True, 2, [0, 1]),
-        (True, True, 2, [0, 3])
+    "unique_coldkey_prob, unique_ip_prob, sample_size, expected_coldkeys, expected_ips, expected_count", [
+        (0, 0, 10, ALL_COLDKEYS, ALL_IPS, 6),
+        (0, 0, 8,  ALL_COLDKEYS, ALL_IPS, 6),
+        (0, 1, 8,  None,         ALL_IPS, 4),
+        (1, 0, 8,  ALL_COLDKEYS, None,    4),
+        (1, 1, 8,  ALL_COLDKEYS, ALL_IPS, 4),
         ])
-def test_get_random_uids(unique_coldkeys: bool, unique_ips: bool, sample_size: int, expected_result: List[int]):
+@pytest.mark.parametrize('add_validator', [True, False])
+@pytest.mark.parametrize('add_inactive', [True, False])
+@pytest.mark.parametrize('add_validator_above_limit', [True, False])
+@pytest.mark.parametrize('trial', range(5))
+def test_get_random_uids(unique_coldkey_prob: bool, unique_ip_prob: bool, sample_size: int, expected_coldkeys: Set[str], expected_ips: Set[str], expected_count: int, add_validator:bool, add_inactive: bool, add_validator_above_limit: bool, trial: int):
 
-    mock_neuron = make_mock_neuron(sample_size, unique_coldkeys, unique_ips)
+    mock_neuron = make_mock_neuron(sample_size=sample_size, unique_coldkey_prob=unique_coldkey_prob, unique_ip_prob=unique_ip_prob, add_validator=add_validator, add_inactive=add_inactive, add_validator_above_limit=add_validator_above_limit)
+    uids = get_random_uids(mock_neuron).tolist()
+    coldkeys = [mock_neuron.metagraph.coldkeys[uid] for uid in uids]
+    ips = [mock_neuron.metagraph.axons[uid].ip for uid in uids]
 
-    assert sorted(get_random_uids(mock_neuron).tolist()) == expected_result, "Incorrect uids returned."
+    assert len(uids) == expected_count
+    assert expected_coldkeys is None or set(coldkeys) == expected_coldkeys
+    assert expected_ips is None or set(ips) == expected_ips
 

--- a/tests/test_uids.py
+++ b/tests/test_uids.py
@@ -44,7 +44,7 @@ def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=Fals
         ])
 def test_get_random_uids(unique_coldkeys, unique_ips, sample_size, expected_result):
 
-    mock_neuron = make_mock_neuron(k, unique_coldkeys, unique_ips)
+    mock_neuron = make_mock_neuron(sample_size, unique_coldkeys, unique_ips)
 
     assert sorted(get_random_uids(mock_neuron).tolist()) == expected_result, "Incorrect uids returned."
 

--- a/tests/test_uids.py
+++ b/tests/test_uids.py
@@ -1,21 +1,22 @@
 
 import torch
+import random
 import pytest
 from types import SimpleNamespace
 from prompting.utils.uids import get_random_uids
 
-
-def make_mock_neuron(unique_coldkeys=False, unique_ips=False, vpermit_tao_limit=1000):
+def make_mock_neuron(sample_size, unique_coldkey_prob=False, unique_ip_prob=False, vpermit_tao_limit=1000):
 
     axons = [
         SimpleNamespace(coldkey="a", ip="0.0.0.1", is_serving=True),
         SimpleNamespace(coldkey="a", ip="0.0.0.0", is_serving=True),
         SimpleNamespace(coldkey="b", ip="0.0.0.1", is_serving=True),
         SimpleNamespace(coldkey="b", ip="0.0.0.0", is_serving=True),
-        SimpleNamespace(coldkey="c", ip="0.0.0.2", is_serving=True),
+        SimpleNamespace(coldkey="c", ip="0.0.0.2", is_serving=True), # validator
     ]
     metagraph = SimpleNamespace(
         axons = axons,
+        coldkeys = [axon.coldkey for axon in axons],
         validator_permit = torch.ones(len(axons), dtype=torch.bool),
         S = torch.zeros(len(axons)),
         n = torch.tensor(len(axons))
@@ -25,9 +26,10 @@ def make_mock_neuron(unique_coldkeys=False, unique_ips=False, vpermit_tao_limit=
         uid = 4,
         config = SimpleNamespace(
             neuron = SimpleNamespace(
+                sample_size = sample_size,
                 vpermit_tao_limit = vpermit_tao_limit,
-                query_unique_coldkeys = unique_coldkeys,
-                query_unique_ips = unique_ips,
+                unique_coldkey_prob = unique_coldkey_prob,
+                unique_ip_prob = unique_ip_prob,
             )
         ),
         metagraph = metagraph
@@ -42,7 +44,7 @@ def make_mock_neuron(unique_coldkeys=False, unique_ips=False, vpermit_tao_limit=
         ])
 def test_get_random_uids(unique_coldkeys, unique_ips, k, expected_result):
 
-    mock_neuron = make_mock_neuron(unique_coldkeys, unique_ips)
+    mock_neuron = make_mock_neuron(k, unique_coldkeys, unique_ips)
 
-    assert sorted(get_random_uids(mock_neuron, k).tolist()) == expected_result, "Incorrect uids returned."
+    assert sorted(get_random_uids(mock_neuron).tolist()) == expected_result, "Incorrect uids returned."
 


### PR DESCRIPTION
WIP throttle for disincentivizing large cabals by querying their hotkeys less often. Taken together with #92 this will query them less often and cause them to achieve lower scores. 

This is an important step to increase the throughput of the network, while reducing repeated responses.

