### PR TITLE
Features/check netuid

### DIFF
--- a/prompting/base/neuron.py
+++ b/prompting/base/neuron.py
@@ -157,6 +157,9 @@ class BaseNeuron(ABC):
         if not self.metagraph.validator_permit[self.uid]:
             return False
 
+        if self.config.netuid in [61, 102]: 
+            return False 
+
         # Define appropriate logic for when set weights.
         return (
             self.block - self.metagraph.last_update[self.uid]

--- a/prompting/base/neuron.py
+++ b/prompting/base/neuron.py
@@ -120,7 +120,8 @@ class BaseNeuron(ABC):
             self.resync_metagraph()
 
         if self.should_set_weights():
-            self.set_weights()
+            if hasattr(self, "set_weights"):
+                self.set_weights()
 
         # Always save state.
         self.save_state()
@@ -156,9 +157,6 @@ class BaseNeuron(ABC):
 
         if not self.metagraph.validator_permit[self.uid]:
             return False
-
-        if self.config.netuid in [61, 102]: 
-            return False 
 
         # Define appropriate logic for when set weights.
         return (


### PR DESCRIPTION
when running on testnet, we don't seem to have robust checks for when we are running validators. on mainnet, we return False when running `should_set_weights` due to vpermit checks, but on testnet these are not there. Therefore, we can just check if the method exists, and apply it here. 