### PR TITLE
Adds forward time tracking

### DIFF
--- a/prompting/forward.py
+++ b/prompting/forward.py
@@ -94,13 +94,12 @@ async def run_step(
         **response_event.__state_dict__(),
     }
 
-    log_event(self, event)
-
     return event
 
 
 async def forward(self):
     bt.logging.info("🚀 Starting forward loop...")
+    forward_start_time = time.time()
 
     while True:
         bt.logging.info(
@@ -137,6 +136,11 @@ async def forward(self):
             timeout=self.config.neuron.timeout,
             exclude=exclude_uids,
         )
+        
+        # Adds forward time to event and logs it to wandb
+        event['forward_time'] = time.time() - forward_start_time        
+        log_event(self, event)
+        
         exclude_uids += event["uids"]
         task.complete = True
 


### PR DESCRIPTION
Adds new wandb time metric to track the `forward` call time (which includes **task creation** and **agent creation** that are not included in `step_time`).

