### PR TITLE
Add Chattensor System Prompt

### DIFF
--- a/prompting/tasks/qa.py
+++ b/prompting/tasks/qa.py
@@ -19,13 +19,6 @@ Ask a specific question about the following context:
 {context}
 """
 
-# Used to instruct the LLM to provide a good answer to the query when given a context
-REFERENCE_SYSTEM_PROMPT = """\
-You are a question-answering expert, focusing on delivering comprehensive and accurate responses with depth and clarity.
-You will maintain a neutral tone in your explanations.
-You will adhere to a word limit of 150 words for each response. Where applicable, include references to credible sources to support your answers.
-"""
-
 # Used to obtain reference answer
 REFERENCE_PROMPT_TEMPLATE = """\
 Answer the question you will receive in detail, utilizing the following context.
@@ -65,7 +58,6 @@ class QuestionAnsweringTask(Task):
         self.query_prompt = QUERY_PROMPT_TEMPLATE.format(context=context.content)
         self.query = self.generate_query(llm_pipeline)
 
-        self.reference_system_prompt = REFERENCE_SYSTEM_PROMPT
         self.reference_prompt = REFERENCE_PROMPT_TEMPLATE.format(
             context=context.content, question=self.query
         )

--- a/prompting/tasks/summarization.py
+++ b/prompting/tasks/summarization.py
@@ -8,13 +8,6 @@ from transformers import Pipeline
 # TODO: Also add a query system prompt and a query prompt template
 # TODO: Add the option to generate the summary query from the context. e.g. "the childhood of Abraham Lincoln" which is more specific than summarizing the entire article (Abraham Lincoln)
 
-# Used to instruct the LLM to provide a good answer to the query when given a context
-SUMMARIZATION_SYSTEM_PROMPT = """\
-You are a summarization AI assistant. You make excellent and concise summaries that adhere to your given instructions.
-You will maintain a neutral tone in your summaries.
-You will adhere to a word limit of 250 words for each response.
-"""
-
 # Used to obtain reference answer
 REFERENCE_PROMPT_TEMPLATE = """\
 Summarize the following context in a concise and accurate manner:
@@ -52,7 +45,6 @@ class SummarizationTask(Task):
         # Query is just the article title and section name
         self.query = context.title + ", " + context.topic
 
-        self.reference_system_prompt = SUMMARIZATION_SYSTEM_PROMPT
         self.reference_prompt = REFERENCE_PROMPT_TEMPLATE.format(
             context=context.content
         )

--- a/prompting/tasks/task.py
+++ b/prompting/tasks/task.py
@@ -7,7 +7,16 @@ from typing import List, Union, Dict
 from prompting.llms import HuggingFaceLLM, vLLM_LLM, BasePipeline
 from prompting.cleaners.cleaner import CleanerPipeline
 
+CHATTENSOR_SYSTEM_PROMPT = """
+The assistant is Chattensor, created by Macrocosmos. The current date is {date}.
+Chattensor is a distributed intelligence, powered by Bittensor. It is a hivemind composed of 1000 highly skilled and specialized LLMs working together to provide the best possible answers to human queries. Within Chattenor, each LLM has access to the internet, APIs and tools to ensure that responses are current and factually accurate. It should give concise responses to very simple questions, but provide thorough responses to more complex and open-ended questions.
+It is happy to help with writing, analysis, question answering, math, coding, and all sorts of other tasks. It uses markdown for coding. Where applicable, Chattensor will include references to credible sources to support its answers.
+It does not mention this information about itself unless the information is directly pertinent to the human's query.
+"""
 
+
+def make_system_prompt():
+    return CHATTENSOR_SYSTEM_PROMPT.format(date=time.strftime("%B %d, %Y"))
 class TaskEvaluationType(Enum):
     REWARD_STACK = "reward"
     FILTER_STACK = "filter"
@@ -85,7 +94,7 @@ class Task(ABC):
             bt.logging.info("🤖 Generating reference...")
 
             self.reference = self.generate(
-                system=self.reference_system_prompt,
+                system=make_system_prompt(),
                 prompt=self.reference_prompt,
                 pipeline=pipeline,
                 clean=clean,
@@ -100,7 +109,7 @@ class Task(ABC):
         if not self.static_query:
             bt.logging.info("🤖 Generating query...")
             self.query = self.generate(
-                system=self.query_system_prompt,
+                system=self.query_system_prompt, #Could possibly add the chattensor system prompt to query but I don't think it adds anything
                 prompt=self.query_prompt,
                 pipeline=pipeline,
                 clean=clean,

--- a/prompting/tasks/task.py
+++ b/prompting/tasks/task.py
@@ -45,7 +45,6 @@ class Task(ABC):
     complete: bool = False
     static_reference: bool = False
     static_query: bool = False
-    reference_system_prompt = ""
     reference_prompt = ""
     query_system_prompt = ""
     query_prompt = ""

--- a/tests/fixtures/task.py
+++ b/tests/fixtures/task.py
@@ -43,7 +43,6 @@ TASK_FIELDS = {
     "complete": bool,
     "static_reference": bool,
     "static_query": bool,
-    "reference_system_prompt": str,
     "reference_prompt": str,
     "query_system_prompt": str,
     "query_prompt": str,


### PR DESCRIPTION
This adds the chattensor system prompt to reference generation to aid in the creation of an identity for the miners of SN1. Experiments are necessary to see the effects of the system prompt on the quality of references. 