### PR TITLE
moves validator code into prompting package

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -15,84 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 import time
-import torch
 import bittensor as bt
-from prompting.forward import forward
-from prompting.llms import HuggingFacePipeline, vLLMPipeline
-from prompting.base.validator import BaseValidatorNeuron
-from prompting.rewards import RewardPipeline
-
-
-class Validator(BaseValidatorNeuron):
-    """
-    Text prompt validator neuron.
-    """
-
-    def __init__(self, config=None):
-        super(Validator, self).__init__(config=config)
-
-        bt.logging.info("load_state()")
-        self.load_state()
-
-        self.llm_pipeline = vLLMPipeline(
-            model_id=self.config.neuron.model_id,
-            device=self.device,
-            mock=self.config.mock,
-        )
-
-        if abs(1-sum(self.config.neuron.task_p)) > 0.001:
-            raise ValueError("Task probabilities do not sum to 1.")
-
-        # Filter out tasks with 0 probability
-        self.active_tasks = [
-            task
-            for task, p in zip(self.config.neuron.tasks, self.config.neuron.task_p)
-            if p > 0
-        ]
-        # Load the reward pipeline
-        self.reward_pipeline = RewardPipeline(
-            selected_tasks=self.active_tasks, device=self.device
-        )
-
-    async def forward(self):
-        """
-        Validator forward pass. Consists of:
-        - Generating the query
-        - Querying the miners
-        - Getting the responses
-        - Rewarding the miners
-        - Updating the scores
-        """
-        return await forward(self)
-
-    def __enter__(self):
-        if self.config.no_background_thread:
-            bt.logging.warning("Running validator in main thread.")
-            self.run()
-        else:
-            self.run_in_background_thread()
-
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """
-        Stops the validator's background operations upon exiting the context.
-        This method facilitates the use of the validator in a 'with' statement.
-
-        Args:
-            exc_type: The type of the exception that caused the context to be exited.
-                      None if the context was exited without an exception.
-            exc_value: The instance of the exception that caused the context to be exited.
-                       None if the context was exited without an exception.
-            traceback: A traceback object encoding the stack trace.
-                       None if the context was exited without an exception.
-        """
-        if self.is_running:
-            bt.logging.debug("Stopping validator in background thread.")
-            self.should_exit = True
-            self.thread.join(5)
-            self.is_running = False
-            bt.logging.debug("Stopped")
+from prompting.validator import Validator
 
 
 # The main function parses the configuration and runs the validator.

--- a/prompting/__init__.py
+++ b/prompting/__init__.py
@@ -36,6 +36,7 @@ from . import forward
 from . import agent
 from . import conversation
 from . import dendrite
+from . import validator
 
 from .llms import hf
 

--- a/prompting/validator.py
+++ b/prompting/validator.py
@@ -1,0 +1,78 @@
+import bittensor as bt
+from prompting.forward import forward
+from prompting.llms import vLLMPipeline
+from prompting.base.validator import BaseValidatorNeuron
+from prompting.rewards import RewardPipeline
+
+
+class Validator(BaseValidatorNeuron):
+    """
+    Text prompt validator neuron.
+    """
+
+    def __init__(self, config=None):
+        super(Validator, self).__init__(config=config)
+
+        bt.logging.info("load_state()")
+        self.load_state()
+
+        self.llm_pipeline = vLLMPipeline(
+            model_id=self.config.neuron.model_id,
+            device=self.device,
+            mock=self.config.mock,
+        )
+
+        if abs(1-sum(self.config.neuron.task_p)) > 0.001:
+            raise ValueError("Task probabilities do not sum to 1.")
+
+        # Filter out tasks with 0 probability
+        self.active_tasks = [
+            task
+            for task, p in zip(self.config.neuron.tasks, self.config.neuron.task_p)
+            if p > 0
+        ]
+        # Load the reward pipeline
+        self.reward_pipeline = RewardPipeline(
+            selected_tasks=self.active_tasks, device=self.device
+        )
+
+    async def forward(self):
+        """
+        Validator forward pass. Consists of:
+        - Generating the query
+        - Querying the miners
+        - Getting the responses
+        - Rewarding the miners
+        - Updating the scores
+        """
+        return await forward(self)
+
+    def __enter__(self):
+        if self.config.no_background_thread:
+            bt.logging.warning("Running validator in main thread.")
+            self.run()
+        else:
+            self.run_in_background_thread()
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Stops the validator's background operations upon exiting the context.
+        This method facilitates the use of the validator in a 'with' statement.
+
+        Args:
+            exc_type: The type of the exception that caused the context to be exited.
+                      None if the context was exited without an exception.
+            exc_value: The instance of the exception that caused the context to be exited.
+                       None if the context was exited without an exception.
+            traceback: A traceback object encoding the stack trace.
+                       None if the context was exited without an exception.
+        """
+        if self.is_running:
+            bt.logging.debug("Stopping validator in background thread.")
+            self.should_exit = True
+            self.thread.join(5)
+            self.is_running = False
+            bt.logging.debug("Stopped")
+


### PR DESCRIPTION
This PR moves the validator init code into the prompting package. This facilitates the code to be accessed within the prompting package scope, making in it easy to integrate with `pip install @git/prompting` (useful for applications built on top of prompting code).


