### PR TITLE
Update README and min_compute: Llama3, python 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Validators and miners are based on large language models (LLM). The validation p
 </div>
 
 # Installation
-This repository requires python3.8 or higher. To install it, simply clone this repository and run the [install.sh](./install.sh) script.
+This repository requires python3.9 or higher. To install it, simply clone this repository and run the [install.sh](./install.sh) script.
 ```bash
 git clone https://github.com/opentensor/prompting.git
 cd prompting
@@ -54,7 +54,7 @@ python <SCRIPT_PATH>
     --wallet.name <your wallet> # Must be created using the bittensor-cli
     --wallet.hotkey <your hotkey> # Must be created using the bittensor-cli
     --logging.debug # Run in debug mode, alternatively --logging.trace for trace mode
-    --axon.port #VERY IMPORTANT: set the port to be one of the open TCP ports on your machine
+    --axon.port # VERY IMPORTANT: set the port to be one of the open TCP ports on your machine
 ```
 
 where `SCRIPT_PATH` is either: 
@@ -70,7 +70,7 @@ sudo apt update && sudo apt install jq && sudo apt install npm && sudo npm insta
 
 Example of running a SOLAR miner: 
 ```bash
-pm2 start neurons/miners/huggingface/miner.py --interpreter python3 --name solar_miner -- --netuid 1  --subtensor.network finney --wallet.name my_wallet --wallet.hotkey m1 --neuron.model_id NousResearch/Nous-Hermes-2-SOLAR-10.7B --axon.port 21988 --logging.debug 
+pm2 start neurons/miners/huggingface/miner.py --interpreter python3 --name solar_miner -- --netuid 1  --subtensor.network finney --wallet.name my_wallet --wallet.hotkey m1 --neuron.model_id casperhansen/llama-3-70b-instruct-awq --axon.port 21988 --logging.debug 
 ``` 
 
 # Testnet 
@@ -81,7 +81,7 @@ In order to run on testnet, you will need to go through the same hotkey registra
 To run:
 
 ```bash
-pm2 start neurons/miners/huggingface/miner.py --interpreter python3 --name solar_miner -- --netuid 61  --subtensor.network test --wallet.name my_test_wallet --wallet.hotkey m1 --neuron.model_id NousResearch/Nous-Hermes-2-SOLAR-10.7B --axon.port 21988 --logging.debug 
+pm2 start neurons/miners/huggingface/miner.py --interpreter python3 --name solar_miner -- --netuid 61  --subtensor.network test --wallet.name my_test_wallet --wallet.hotkey m1 --neuron.model_id casperhansen/llama-3-70b-instruct-awq --axon.port 21988 --logging.debug 
 ```
 
 # Limitations

--- a/min_compute.yml
+++ b/min_compute.yml
@@ -57,12 +57,12 @@ compute_spec:
 
     gpu:
       required: True                       # Does the application require a GPU?
-      min_vram: 24                         # Minimum GPU VRAM (GB)
-      recommended_vram: 36                 # Recommended GPU VRAM (GB)
+      min_vram: 80                         # Minimum GPU VRAM (GB)
+      recommended_vram: 80                 # Recommended GPU VRAM (GB)
       cuda_cores: 1024                     # Minimum number of CUDA cores (if applicable)
       min_compute_capability: 6.0          # Minimum CUDA compute capability
       recommended_compute_capability: 7.0  # Recommended CUDA compute capability
-      recommended_gpu: "NVIDIA A10"       # Recommended GPU to purchase/rent
+      recommended_gpu: "NVIDIA A100"       # Recommended GPU to purchase/rent
 
     memory:
       min_ram: 16          # Minimum RAM (GB)
@@ -71,7 +71,7 @@ compute_spec:
       ram_type: "DDR4"     # RAM type (e.g., DDR4, DDR3, etc.)
 
     storage:
-      min_space: 24           # Minimum free storage space (GB)
+      min_space: 40           # Minimum free storage space (GB)
       recommended_space: 100  # Recommended free storage space (GB)
       type: "SSD"             # Preferred storage type (e.g., SSD, HDD)
       min_iops: 1000          # Minimum I/O operations per second (if applicable)


### PR DESCRIPTION
## Changes
  - Update README minimum python version from `3.8` to `3.9`;
  - Update README miner model with `casperhansen/llama-3-70b-instruct-awq`;
  - Increase minimum VRAM requirements from `24` to `80` GB;
  - Increase recommended VRAM requirements from `36` to `80` GB;
  - Increase minimum storage requirements from `24` GB to `40` GB;
  - Change recommended GPU from `NVIDIA A10` to `NVIDIA A100`.
  
  ## Notes
  - This PR is intended for Llama3 upgrade preparation and does not include the model upgrade itself.